### PR TITLE
Fix Vercel serverless exports

### DIFF
--- a/api/get-data.js
+++ b/api/get-data.js
@@ -1,5 +1,5 @@
 // Vercel serverless function to retrieve saved product data
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');

--- a/api/save-data.js
+++ b/api/save-data.js
@@ -1,5 +1,5 @@
 // Vercel serverless function to save product data
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');


### PR DESCRIPTION
## Summary
- use CommonJS export syntax for Vercel functions

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851a75f91a883289aa9d2a2bc266c45