### PR TITLE
Fix Vercel build output path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
-  "version": 2
+  "version": 2,
+  "outputDirectory": "."
 }


### PR DESCRIPTION
## Summary
- configure output directory so Vercel serves static files from repo root

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851aac416588328859bcb41386e251a